### PR TITLE
fixed the bug on catching form validation errors to the response body

### DIFF
--- a/SoloProjectSpring/WizardEmporiumSpring/src/main/java/com/ZachP/WizardEmporiumSpring/models/ControllerErrorHandler.java
+++ b/SoloProjectSpring/WizardEmporiumSpring/src/main/java/com/ZachP/WizardEmporiumSpring/models/ControllerErrorHandler.java
@@ -2,32 +2,32 @@ package com.ZachP.WizardEmporiumSpring.models;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
-import org.springframework.web.context.request.WebRequest;
-import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 
 @ControllerAdvice
-public class ControllerErrorHandler extends ResponseEntityExceptionHandler {
-	
-	protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,HttpHeaders headers,
-			HttpStatus status, WebRequest request){
+public class ControllerErrorHandler {
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+
 		FieldErrorResponse fieldErrorResponse = new FieldErrorResponse();
-		
+
 		List<CustomFieldError> fieldErrors = new ArrayList<>();
-		
-		ex.getBindingResult().getAllErrors().forEach((error) -> {
+
+		ex.getBindingResult().getFieldErrors().forEach((error) -> {
 			CustomFieldError fieldError = new CustomFieldError();
-			fieldError.setField(((FieldError ) error).getField());
+			fieldError.setField(((FieldError) error).getField());
 			fieldError.setMessage(error.getDefaultMessage());
 			fieldErrors.add(fieldError);
 		});
 		fieldErrorResponse.setFieldErrors(fieldErrors);
-		return new ResponseEntity<>(fieldErrorResponse,status);
+		return new ResponseEntity<>(fieldErrorResponse, HttpStatus.BAD_REQUEST);
+
 	}
+
 }


### PR DESCRIPTION
As the title says, I fixed a bug. 
Previously, the server was not able to catch exception related to bad request payload.
In this fix, the server catches an exception related to field errors and returns a response specifying field with errors and an error message.

Please Review.